### PR TITLE
Add evaluation context API and student attempt saving

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -1,7 +1,10 @@
 # Lisan Backend API Documentation
 
 ## Base URL
+
+```text
 http://localhost:3000/api
+```
 
 ---
 
@@ -12,6 +15,8 @@ http://localhost:3000/api
 | `/api/health` | GET | Server health check | No | ✅ |
 | `/api/auth/login` | POST | User login | No | ✅ |
 | `/api/users/me` | GET | Get current user profile | Yes | ✅ |
+| `/api/evaluation/context` | GET | Get evaluation context for speaking assessment | No | ✅ |
+| `/api/evaluation/attempts` | POST | Save student speaking attempt and AI evaluation | No | ✅ |
 
 ---
 
@@ -20,6 +25,7 @@ http://localhost:3000/api
 **GET** `/api/health`
 
 ### Response
+
 ```json
 {
   "status": "ok",
@@ -35,6 +41,7 @@ http://localhost:3000/api
 **POST** `/api/auth/login`
 
 ### Request Body
+
 ```json
 {
   "email": "student@test.com",
@@ -43,6 +50,7 @@ http://localhost:3000/api
 ```
 
 ### Success Response (200)
+
 ```json
 {
   "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -58,6 +66,7 @@ http://localhost:3000/api
 ### Error Responses
 
 #### 400 - Missing fields
+
 ```json
 {
   "error": "Email and password are required"
@@ -65,6 +74,7 @@ http://localhost:3000/api
 ```
 
 #### 401 - Invalid credentials
+
 ```json
 {
   "error": "Invalid credentials"
@@ -72,6 +82,7 @@ http://localhost:3000/api
 ```
 
 #### 423 - Account locked
+
 ```json
 {
   "error": "Account is locked",
@@ -86,11 +97,13 @@ http://localhost:3000/api
 **GET** `/api/users/me`
 
 ### Headers
-```
+
+```text
 Authorization: Bearer <token>
 ```
 
 ### Success Response (200)
+
 ```json
 {
   "id": "abc123",
@@ -105,6 +118,7 @@ Authorization: Bearer <token>
 ### Error Responses
 
 #### 401 - No or invalid token
+
 ```json
 {
   "error": "No token provided"
@@ -120,6 +134,7 @@ or
 ```
 
 #### 404 - User not found
+
 ```json
 {
   "error": "User not found"
@@ -128,9 +143,209 @@ or
 
 ---
 
+## 4. Get Evaluation Context
+
+**GET** `/api/evaluation/context`
+
+### Purpose
+
+Returns a normalized evaluation context for the AI speaking assessment model based on `userId`, `activityId`, and optional `turnId`.
+
+### Query Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `userId` | Yes | Student user ID |
+| `activityId` | Yes | Activity ID |
+| `turnId` | No | Specific dialogue turn ID |
+
+### Example Request
+
+```text
+GET /api/evaluation/context?userId=test_user&activityId=a1_booking_appointment&turnId=turn_01
+```
+
+### Success Response (200)
+
+```json
+{
+  "success": true,
+  "context": {
+    "userId": "test_user",
+    "activityId": "a1_booking_appointment",
+    "turnId": "turn_01",
+    "level": "A1",
+    "skill": "speaking",
+    "activity": {
+      "title": "קביעת תור",
+      "topic": "booking an appointment",
+      "activityMode": "guided_conversation",
+      "analysisDepth": "meaning_only",
+      "targetVocabulary": ["לקבוע תור", "תעודת זהות", "שעה"],
+      "targetGrammar": ["אני רוצה", "אפשר"],
+      "expectedPatterns": [
+        "אני רוצה לקבוע תור",
+        "אפשר לקבוע תור?"
+      ],
+      "referenceText": "אני רוצה לקבוע תור",
+      "strictness": "low",
+      "maxFeedbackItems": 1,
+      "feedbackLanguage": "he",
+      "supportLanguage": "ar",
+      "allowAdvancedCorrectLanguage": true,
+      "simplifyAdvancedLanguage": true
+    },
+    "currentTurn": {
+      "botTextHe": "שלום, איך אפשר לעזור?",
+      "expectedStudentAction": "ask_to_book_appointment",
+      "expectedPatterns": [
+        "אני רוצה לקבוע תור",
+        "אפשר לקבוע תור?"
+      ],
+      "referenceText": "אני רוצה לקבוע תור"
+    },
+    "rubric": {
+      "expectedMeaning": "הסטודנט צריך לבקש לקבוע תור.",
+      "requiredElements": ["request_appointment"],
+      "acceptablePatterns": [
+        "אני רוצה לקבוע תור",
+        "אפשר לקבוע תור?",
+        "ברצוני לקבוע פגישה"
+      ],
+      "commonMistakes": [
+        {
+          "wrong": "לעשות תור",
+          "correct": "לקבוע תור",
+          "type": "vocabulary",
+          "explanationHeSimple": "בעברית אומרים לקבוע תור."
+        }
+      ],
+      "correctionPolicy": {
+        "maxCorrections": 1,
+        "correctOnlyLevelRelevant": true,
+        "ignoreAdvancedStylisticIssues": true,
+        "doNotPunishAdvancedCorrectHebrew": true
+      }
+    },
+    "limits": {
+      "remainingPronunciationChecks": 20,
+      "monthlyPronunciationLimit": 30
+    }
+  }
+}
+```
+
+### Error Responses
+
+#### 400 - Missing query parameters
+
+```json
+{
+  "success": false,
+  "error": "userId and activityId are required",
+  "code": "MISSING_REQUIRED_PARAMS"
+}
+```
+
+#### 404 - Context not found
+
+```json
+{
+  "success": false,
+  "error": "Activity not found",
+  "code": "ACTIVITY_NOT_FOUND"
+}
+```
+
+---
+
+## 5. Save Student Attempt
+
+**POST** `/api/evaluation/attempts`
+
+### Purpose
+
+Saves a student speaking attempt after STT recognition and AI evaluation.
+
+### Request Body
+
+```json
+{
+  "userId": "test_user",
+  "activityId": "a1_booking_appointment",
+  "turnId": "turn_01",
+  "recognizedTextHe": "אני רוצה לקבוע תור",
+  "aiEvaluation": {
+    "feedbackHe": "יפה מאוד",
+    "isMeaningCorrect": true
+  },
+  "usage": {
+    "level": "A1",
+    "referenceText": "אני רוצה לקבוע תור",
+    "usedAzurePronunciation": false,
+    "costMode": "standard"
+  }
+}
+```
+
+### Success Response (201)
+
+```json
+{
+  "success": true,
+  "attempt": {
+    "id": "YgRiLFYHMpE0FIVd54ur",
+    "userId": "test_user",
+    "activityId": "a1_booking_appointment",
+    "turnId": "turn_01",
+    "level": "A1",
+    "recognizedTextHe": "אני רוצה לקבוע תור",
+    "referenceText": "אני רוצה לקבוע תור",
+    "aiEvaluation": {
+      "feedbackHe": "יפה מאוד",
+      "isMeaningCorrect": true
+    },
+    "usedAzurePronunciation": false,
+    "costMode": "standard",
+    "createdAt": "2026-05-16T16:59:41.431Z"
+  }
+}
+```
+
+### Error Responses
+
+#### 400 - Missing required fields
+
+```json
+{
+  "success": false,
+  "error": "userId, activityId, and recognizedTextHe are required",
+  "code": "MISSING_REQUIRED_FIELDS"
+}
+```
+
+#### 500 - Server error
+
+```json
+{
+  "success": false,
+  "error": "Server error",
+  "code": "SERVER_ERROR"
+}
+```
+
+---
+
 ## Example cURL Commands
 
+### Health Check
+
+```bash
+curl http://localhost:3000/api/health
+```
+
 ### Login
+
 ```bash
 curl -X POST http://localhost:3000/api/auth/login \
 -H "Content-Type: application/json" \
@@ -138,7 +353,37 @@ curl -X POST http://localhost:3000/api/auth/login \
 ```
 
 ### Get Current User
+
 ```bash
 curl http://localhost:3000/api/users/me \
 -H "Authorization: Bearer <token>"
+```
+
+### Get Evaluation Context
+
+```bash
+curl "http://localhost:3000/api/evaluation/context?userId=test_user&activityId=a1_booking_appointment&turnId=turn_01"
+```
+
+### Save Student Attempt
+
+```bash
+curl -X POST http://localhost:3000/api/evaluation/attempts \
+-H "Content-Type: application/json" \
+-d '{
+  "userId": "test_user",
+  "activityId": "a1_booking_appointment",
+  "turnId": "turn_01",
+  "recognizedTextHe": "אני רוצה לקבוע תור",
+  "aiEvaluation": {
+    "feedbackHe": "יפה מאוד",
+    "isMeaningCorrect": true
+  },
+  "usage": {
+    "level": "A1",
+    "referenceText": "אני רוצה לקבוע תור",
+    "usedAzurePronunciation": false,
+    "costMode": "standard"
+  }
+}'
 ```

--- a/backend/seedEvaluationContext.js
+++ b/backend/seedEvaluationContext.js
@@ -1,0 +1,183 @@
+const { admin, db } = require('./src/config/firebase');
+
+async function seedEvaluationContext() {
+  try {
+
+    // =========================
+    // User
+    // =========================
+
+    await db.collection('users').doc('test_user').set({
+
+      name: 'Test Student',
+
+      level: 'A1',
+
+      role: 'student',
+
+      currentUnitId: 'unit_a1_01',
+
+      currentActivityId: 'a1_booking_appointment',
+
+      pronunciationUsage: {
+        monthlyLimit: 30,
+        usedThisMonth: 10
+      }
+    });
+
+    // =========================
+    // Activity
+    // =========================
+
+    await db
+      .collection('activities')
+      .doc('a1_booking_appointment')
+      .set({
+
+        unitId: 'unit_a1_01',
+
+        level: 'A1',
+
+        skill: 'speaking',
+
+        title: 'קביעת תור',
+
+        topic: 'booking an appointment',
+
+        activityMode: 'guided_conversation',
+
+        analysisDepth: 'meaning_only',
+
+        targetVocabulary: [
+          'לקבוע תור',
+          'תעודת זהות',
+          'שעה'
+        ],
+
+        targetGrammar: [
+          'אני רוצה',
+          'אפשר'
+        ],
+
+        expectedPatterns: [
+          'אני רוצה לקבוע תור',
+          'אפשר לקבוע תור?'
+        ],
+
+        referenceText:
+          'אני רוצה לקבוע תור',
+
+        strictness: 'low',
+
+        maxFeedbackItems: 1,
+
+        feedbackLanguage: 'he',
+
+        supportLanguage: 'ar',
+
+        allowAdvancedCorrectLanguage: true,
+
+        simplifyAdvancedLanguage: true,
+
+        isActive: true
+      });
+
+    // =========================
+    // Turn
+    // =========================
+
+    await db
+      .collection('activities')
+      .doc('a1_booking_appointment')
+      .collection('turns')
+      .doc('turn_01')
+      .set({
+
+        order: 1,
+
+        speaker: 'bot',
+
+        botTextHe:
+          'שלום, איך אפשר לעזור?',
+
+        expectedStudentAction:
+          'ask_to_book_appointment',
+
+        expectedPatterns: [
+          'אני רוצה לקבוע תור',
+          'אפשר לקבוע תור?'
+        ],
+
+        referenceText:
+          'אני רוצה לקבוע תור',
+
+        rubricId:
+          'rubric_booking_appointment'
+      });
+
+    // =========================
+    // Rubric
+    // =========================
+
+    await db
+      .collection('rubrics')
+      .doc('rubric_booking_appointment')
+      .set({
+
+        activityId:
+          'a1_booking_appointment',
+
+        level: 'A1',
+
+        expectedMeaning:
+          'הסטודנט צריך לבקש לקבוע תור.',
+
+        requiredElements: [
+          'request_appointment'
+        ],
+
+        acceptablePatterns: [
+          'אני רוצה לקבוע תור',
+          'אפשר לקבוע תור?',
+          'ברצוני לקבוע פגישה'
+        ],
+
+        commonMistakes: [
+          {
+            wrong: 'לעשות תור',
+
+            correct: 'לקבוע תור',
+
+            type: 'vocabulary',
+
+            explanationHeSimple:
+              'בעברית אומרים לקבוע תור.'
+          }
+        ],
+
+        correctionPolicy: {
+
+          maxCorrections: 1,
+
+          correctOnlyLevelRelevant: true,
+
+          ignoreAdvancedStylisticIssues: true,
+
+          doNotPunishAdvancedCorrectHebrew: true
+        }
+      });
+
+    console.log(
+      '✅ Evaluation context seeded successfully'
+    );
+
+  } catch (error) {
+
+    console.error(
+      '❌ Seed error:',
+      error
+    );
+  }
+}
+
+seedEvaluationContext();

--- a/backend/src/config/firebase.js
+++ b/backend/src/config/firebase.js
@@ -3,8 +3,12 @@ const path = require('path');
 
 const serviceAccount = require(path.join(__dirname, '../../privateKey.json'));
 
-admin.initializeApp({
-  credential: admin.credential.cert(serviceAccount)
-});
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount)
+  });
+}
 
-module.exports = admin;
+const db = admin.firestore();
+
+module.exports = { admin, db };

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,8 +1,6 @@
-const admin = require('../config/firebase');
+const { admin, db } = require('../config/firebase');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-
-const db = admin.firestore();
 
 exports.login = async (req, res) => {
   try {

--- a/backend/src/controllers/evaluationController.js
+++ b/backend/src/controllers/evaluationController.js
@@ -1,0 +1,78 @@
+const {
+    getEvaluationContext,
+    saveStudentAttempt
+} = require('../services/evaluationContextService');
+
+exports.getContext = async (req, res) => {
+    try {
+        const { userId, activityId, turnId } = req.query;
+
+        if (!userId || !activityId) {
+            return res.status(400).json({
+                success: false,
+                error: 'userId and activityId are required',
+                code: 'MISSING_REQUIRED_PARAMS'
+            });
+        }
+
+        const context = await getEvaluationContext({
+            userId,
+            activityId,
+            turnId
+        });
+
+        return res.status(200).json({
+            success: true,
+            context
+        });
+    } catch (error) {
+        return res.status(404).json({
+            success: false,
+            error: error.message || 'Context not found',
+            code: error.code || 'CONTEXT_NOT_FOUND'
+        });
+    }
+};
+
+exports.saveAttempt = async (req, res) => {
+    try {
+        const {
+            userId,
+            activityId,
+            turnId,
+            recognizedTextHe,
+            aiEvaluation,
+            usage
+        } = req.body;
+
+        if (!userId || !activityId || !recognizedTextHe) {
+            return res.status(400).json({
+                success: false,
+                error: 'userId, activityId, and recognizedTextHe are required',
+                code: 'MISSING_REQUIRED_FIELDS'
+            });
+        }
+
+        const attempt = await saveStudentAttempt({
+            userId,
+            activityId,
+            turnId,
+            recognizedTextHe,
+            aiEvaluation,
+            usage
+        });
+
+        return res.status(201).json({
+            success: true,
+            attempt
+        });
+    } catch (error) {
+        console.error('Save attempt error:', error);
+
+        return res.status(500).json({
+            success: false,
+            error: 'Server error',
+            code: 'SERVER_ERROR'
+        });
+    }
+};

--- a/backend/src/controllers/transcriptsController.js
+++ b/backend/src/controllers/transcriptsController.js
@@ -1,6 +1,4 @@
-const admin = require('../config/firebase');
-
-const db = admin.firestore();
+const { db } = require('../config/firebase');
 
 exports.getAllTranscripts = async (req, res) => {
     try {

--- a/backend/src/controllers/usersController.js
+++ b/backend/src/controllers/usersController.js
@@ -1,6 +1,4 @@
-const admin = require('../config/firebase');
-
-const db = admin.firestore();
+const { db } = require('../config/firebase');
 
 exports.getMe = async (req, res) => {
   try {

--- a/backend/src/routes/evaluation.js
+++ b/backend/src/routes/evaluation.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+const router = express.Router();
+
+const evaluationController = require('../controllers/evaluationController');
+
+router.get('/context', evaluationController.getContext);
+router.post('/attempts', evaluationController.saveAttempt);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,6 +8,7 @@ dotenv.config();
 const authRoutes = require('./routes/auth');
 const usersRoutes = require('./routes/users');
 const transcriptsRoutes = require('./routes/transcripts');
+const evaluationRoutes = require('./routes/evaluation');
 require('./config/firebase');
 
 const app = express();
@@ -46,7 +47,7 @@ app.get('/api/health', (req, res) => {
 app.use('/api/auth', authRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/transcripts', transcriptsRoutes);
-
+app.use('/api/evaluation', evaluationRoutes);
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/backend/src/services/evaluationContextService.js
+++ b/backend/src/services/evaluationContextService.js
@@ -1,0 +1,245 @@
+const { db } = require('../config/firebase');
+
+async function getEvaluationContext({
+  userId,
+  activityId,
+  turnId
+}) {
+
+  // =========================
+  // 1) Get user
+  // =========================
+
+  const userDoc = await db
+    .collection('users')
+    .doc(userId)
+    .get();
+
+  if (!userDoc.exists) {
+    throw {
+      code: 'USER_NOT_FOUND',
+      message: 'User not found'
+    };
+  }
+
+  const user = userDoc.data();
+
+  // =========================
+  // 2) Get activity
+  // =========================
+
+  const activityDoc = await db
+    .collection('activities')
+    .doc(activityId)
+    .get();
+
+  if (!activityDoc.exists) {
+    throw {
+      code: 'ACTIVITY_NOT_FOUND',
+      message: 'Activity not found'
+    };
+  }
+
+  const activity = activityDoc.data();
+
+  // =========================
+  // 3) Get turn (optional)
+  // =========================
+
+  let currentTurn = null;
+
+  if (turnId) {
+
+    const turnDoc = await db
+      .collection('activities')
+      .doc(activityId)
+      .collection('turns')
+      .doc(turnId)
+      .get();
+
+    if (turnDoc.exists) {
+      currentTurn = turnDoc.data();
+    }
+  }
+
+  // =========================
+  // 4) Get rubric
+  // =========================
+
+  let rubric = {};
+
+  if (currentTurn?.rubricId) {
+
+    const rubricDoc = await db
+      .collection('rubrics')
+      .doc(currentTurn.rubricId)
+      .get();
+
+    if (rubricDoc.exists) {
+      rubric = rubricDoc.data();
+    }
+  }
+
+  // =========================
+  // 5) Build normalized context
+  // =========================
+
+  const level =
+    user.level ||
+    activity.level ||
+    'A1';
+
+  const monthlyLimit =
+    user.pronunciationUsage?.monthlyLimit || 30;
+
+  const usedThisMonth =
+    user.pronunciationUsage?.usedThisMonth || 0;
+
+  return {
+
+    userId,
+    activityId,
+    turnId: turnId || null,
+
+    level,
+
+    skill:
+      activity.skill || 'speaking',
+
+    activity: {
+
+      title:
+        activity.title || '',
+
+      topic:
+        activity.topic || '',
+
+      activityMode:
+        activity.activityMode ||
+        'guided_conversation',
+
+      analysisDepth:
+        activity.analysisDepth ||
+        (level === 'A1' || level === 'A2'
+          ? 'meaning_only'
+          : 'standard'),
+
+      targetVocabulary:
+        activity.targetVocabulary || [],
+
+      targetGrammar:
+        activity.targetGrammar || [],
+
+      expectedPatterns:
+        activity.expectedPatterns || [],
+
+      referenceText:
+        activity.referenceText || '',
+
+      strictness:
+        activity.strictness || 'low',
+
+      maxFeedbackItems:
+        activity.maxFeedbackItems ||
+        (level === 'A1' || level === 'A2'
+          ? 1
+          : 2),
+
+      feedbackLanguage:
+        activity.feedbackLanguage || 'he',
+
+      supportLanguage:
+        activity.supportLanguage || 'ar',
+
+      allowAdvancedCorrectLanguage:
+        activity.allowAdvancedCorrectLanguage ?? true,
+
+      simplifyAdvancedLanguage:
+        activity.simplifyAdvancedLanguage ?? true
+    },
+
+    currentTurn: currentTurn
+      ? {
+          botTextHe:
+            currentTurn.botTextHe || '',
+
+          expectedStudentAction:
+            currentTurn.expectedStudentAction || '',
+
+          expectedPatterns:
+            currentTurn.expectedPatterns || [],
+
+          referenceText:
+            currentTurn.referenceText || ''
+        }
+      : null,
+
+    rubric: {
+
+      expectedMeaning:
+        rubric.expectedMeaning || '',
+
+      requiredElements:
+        rubric.requiredElements || [],
+
+      acceptablePatterns:
+        rubric.acceptablePatterns || [],
+
+      commonMistakes:
+        rubric.commonMistakes || [],
+
+      correctionPolicy:
+        rubric.correctionPolicy || {
+          maxCorrections: 1,
+          correctOnlyLevelRelevant: true,
+          ignoreAdvancedStylisticIssues: true,
+          doNotPunishAdvancedCorrectHebrew: true
+        }
+    },
+
+    limits: {
+
+      remainingPronunciationChecks:
+        monthlyLimit - usedThisMonth,
+
+      monthlyPronunciationLimit:
+        monthlyLimit
+    }
+  };
+}
+
+async function saveStudentAttempt({
+  userId,
+  activityId,
+  turnId,
+  recognizedTextHe,
+  aiEvaluation,
+  usage
+}) {
+  const attemptData = {
+    userId,
+    activityId,
+    turnId: turnId || null,
+    level: usage?.level || null,
+    recognizedTextHe,
+    referenceText: usage?.referenceText || '',
+    aiEvaluation: aiEvaluation || null,
+    usedAzurePronunciation: usage?.usedAzurePronunciation || false,
+    costMode: usage?.costMode || 'standard',
+    createdAt: new Date().toISOString()
+  };
+
+  const docRef = await db
+    .collection('studentAttempts')
+    .add(attemptData);
+
+  return {
+    id: docRef.id,
+    ...attemptData
+  };
+}
+
+module.exports = {
+  getEvaluationContext,
+  saveStudentAttempt
+};


### PR DESCRIPTION
## Summary

Implemented evaluation context infrastructure for AI speaking assessment integration.

## Features

* Firebase access layer exporting `{ admin, db }`
* Evaluation context service
* Normalized context generation
* Evaluation context API endpoint
* Student attempt saving endpoint
* Firestore integration
* Seeded test activity and rubric
* API documentation update

## Endpoints

### GET /api/evaluation/context

Returns normalized activity evaluation context.

### POST /api/evaluation/attempts

Saves student speaking attempts and AI evaluation.

## Firestore Collections

* users
* activities
* turns
* rubrics
* studentAttempts

## Testing

Tested successfully with:

```text
GET /api/evaluation/context?userId=test_user&activityId=a1_booking_appointment&turnId=turn_01
```

and:

```text
POST /api/evaluation/attempts
```
