### PR TITLE
Increase font sizes across home, games, vocab game, chatbot, and admi…

### DIFF
--- a/frontend/src/components/VocabGame.jsx
+++ b/frontend/src/components/VocabGame.jsx
@@ -27,6 +27,7 @@ import {
   getUniqueGameWords,
 } from '../data/vocabGameCatalog.js';
 import { COLOR_MAP, getCategoryMeta } from '../data/vocabGameMeta.js';
+import { speakHebrew } from '../services/tts.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 const PASS_THRESHOLD = 6;
@@ -125,54 +126,6 @@ const LABELS = {
     fromLevel: 'שלב',
   },
 };
-
-function getHebrewVoice() {
-  if (typeof window === 'undefined' || !window.speechSynthesis) {
-    return null;
-  }
-
-  const voices = window.speechSynthesis.getVoices?.() || [];
-
-  return (
-    voices.find((voice) => voice.lang === 'he-IL') ||
-    voices.find((voice) => voice.lang === 'he') ||
-    voices.find((voice) => String(voice.lang || '').startsWith('he-')) ||
-    null
-  );
-}
-
-function pronounce(text) {
-  const spokenText = typeof text === 'string' ? text.trim() : '';
-
-  if (!spokenText || typeof window === 'undefined' || !window.speechSynthesis) {
-    return;
-  }
-
-  const doSpeak = () => {
-    const utterance = new SpeechSynthesisUtterance(spokenText);
-    utterance.lang = 'he-IL';
-    utterance.rate = 0.85;
-    utterance.pitch = 1;
-    utterance.volume = 1;
-
-    const hebrewVoice = getHebrewVoice();
-    if (hebrewVoice) {
-      utterance.voice = hebrewVoice;
-    }
-
-    window.speechSynthesis.cancel();
-    window.setTimeout(() => {
-      window.speechSynthesis.speak(utterance);
-    }, 50);
-  };
-
-  const voices = window.speechSynthesis.getVoices?.() || [];
-  if (voices.length > 0) {
-    doSpeak();
-  } else {
-    window.speechSynthesis.addEventListener('voiceschanged', doSpeak, { once: true });
-  }
-}
 
 function shuffle(arr) {
   const copy = [...arr];
@@ -511,21 +464,21 @@ function VocabGame() {
       <div className="mb-5 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-50 px-3 py-1 text-sm font-black text-violet-700">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-50 px-3 py-1 text-base font-black text-violet-700">
               <Gamepad2 className="h-4 w-4" aria-hidden="true" />
               {text.badge}
             </span>
-            <span className="rounded-full bg-white px-3 py-1 text-sm font-bold text-slate-500">
+            <span className="rounded-full bg-white px-3 py-1 text-base font-bold text-slate-500">
               {text.words(totalWordCount)}
             </span>
-            <span className="rounded-full bg-white px-3 py-1 text-sm font-bold text-slate-500">
+            <span className="rounded-full bg-white px-3 py-1 text-base font-bold text-slate-500">
               {text.levels(totalLevelCount)}
             </span>
           </div>
           <h2 className="mt-3 text-[clamp(1.7rem,2.1vw,2.7rem)] font-black text-slate-950">
             {text.title}
           </h2>
-          <p className="mt-2 max-w-3xl text-[clamp(0.95rem,1vw,1.15rem)] font-medium leading-7 text-slate-600">
+          <p className="mt-2 max-w-3xl text-2xl font-medium leading-7 text-slate-600">
             {text.intro}
           </p>
         </div>
@@ -596,11 +549,11 @@ function VocabGame() {
                     <span className="block text-base font-black text-slate-900">
                       {category.meta[language]}
                     </span>
-                    <span className="mt-1 block text-xs font-bold text-slate-500">
+                    <span className="mt-1 block text-base font-bold text-slate-500">
                       {text.completedLevels(completedCount, category.numLevels)}
                     </span>
                   </span>
-                  <span className="mt-auto flex flex-wrap items-center gap-1.5 text-xs font-bold text-slate-500">
+                  <span className="mt-auto flex flex-wrap items-center gap-1.5 text-base font-bold text-slate-500">
                     <span>{text.words(category.totalWords)}</span>
                     <span className="opacity-40">·</span>
                     <span>{text.levels(category.numLevels)}</span>
@@ -656,7 +609,7 @@ function VocabGame() {
                       </div>
                       <button
                         type="button"
-                        onClick={() => pronounce(word.hebrew)}
+                        onClick={() => speakHebrew(word.hebrew)}
                         className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-violet-50 text-violet-700 shadow-sm transition hover:bg-violet-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 active:scale-95"
                         aria-label={text.listen}
                       >
@@ -706,7 +659,7 @@ function VocabGame() {
                 <h3 className="text-[clamp(1.5rem,1.8vw,2.25rem)] font-black text-slate-950">
                   {activeMeta?.[language]}
                 </h3>
-                <p className="text-sm font-bold text-slate-500">
+                <p className="text-lg font-bold text-slate-500">
                   {text.words(activeCategoryData.total_words)} · {text.levels(activeLevels.length)}
                 </p>
               </div>
@@ -720,7 +673,7 @@ function VocabGame() {
               {text.backToCategories}
             </button>
           </div>
-          <p className="mt-2 text-base font-medium leading-7 text-slate-600">
+          <p className="mt-2 text-2xl font-medium leading-7 text-slate-600">
             {text.chooseLevel}
           </p>
           <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-5">
@@ -743,14 +696,14 @@ function VocabGame() {
                   >
                     {isCompleted ? <Check className="h-6 w-6" aria-hidden="true" /> : index + 1}
                   </span>
-                  <span className="mt-2 text-sm font-black text-slate-900">
+                  <span className="mt-2 text-base font-black text-slate-900">
                     {getLevelLabel(index)}
                   </span>
-                  <span className="text-xs font-bold text-slate-400">
+                  <span className="text-sm font-bold text-slate-400">
                     {text.cardCount(words.length)}
                   </span>
                   {isCompleted ? (
-                    <span className="mt-1 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-black text-emerald-700">
+                    <span className="mt-1 rounded-full bg-emerald-50 px-2.5 py-1 text-sm font-black text-emerald-700">
                       {text.completed}
                     </span>
                   ) : null}
@@ -779,7 +732,7 @@ function VocabGame() {
             </button>
           </div>
           <div className="mb-4 flex items-center gap-3">
-            <span dir="ltr" className="text-sm font-bold text-slate-500">
+            <span dir="ltr" className="text-base font-bold text-slate-500">
               {cardIndex + 1} / {levelWords.length}
             </span>
             <div className="h-2 flex-1 overflow-hidden rounded-full bg-violet-100">
@@ -823,7 +776,7 @@ function VocabGame() {
           <div className="mt-3 flex justify-center">
             <button
               type="button"
-              onClick={() => pronounce(currentCard.hebrew)}
+              onClick={() => speakHebrew(currentCard.hebrew)}
               className="inline-flex items-center gap-1.5 rounded-full bg-violet-50 px-4 py-2 text-sm font-bold text-violet-700 shadow-sm transition hover:bg-violet-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 active:scale-95"
             >
               <Volume2 className="h-4 w-4" aria-hidden="true" />
@@ -896,7 +849,7 @@ function VocabGame() {
             </span>
           </div>
           <div className="mb-2 flex items-center gap-3">
-            <span dir="ltr" className="text-sm font-bold text-slate-500">
+            <span dir="ltr" className="text-base font-bold text-slate-500">
               {qIndex + 1} / {questions.length}
             </span>
             <div className="h-2 flex-1 overflow-hidden rounded-full bg-violet-100">
@@ -927,7 +880,7 @@ function VocabGame() {
               </p>
               <button
                 type="button"
-                onClick={() => pronounce(currentQuestion.hebrew)}
+                onClick={() => speakHebrew(currentQuestion.hebrew)}
                 className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-violet-50 text-violet-700 shadow-sm transition hover:bg-violet-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 active:scale-95"
                 aria-label={text.listen}
               >

--- a/frontend/src/pages/GamesPage.jsx
+++ b/frontend/src/pages/GamesPage.jsx
@@ -41,7 +41,7 @@ function GamesPage() {
                 </div>
                 <div className="min-w-0">
                   <h1 className="text-2xl font-black text-slate-950 sm:text-3xl">{text.title}</h1>
-                  <p className="mt-1 text-sm font-bold leading-6 text-slate-600 sm:text-base sm:leading-7">
+                  <p className="mt-1 text-base font-bold leading-6 text-slate-600 sm:text-lg sm:leading-7">
                     {text.description}
                   </p>
                 </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -37,7 +37,7 @@ import {
 } from '../data/vocabGameCatalog.js';
 import { getCategoryMeta, COLOR_MAP } from '../data/vocabGameMeta.js';
 import { getStoredToken, getStoredUser } from '../services/auth.js';
-import { synthesizeSpeech } from '../services/chat.js';
+import { speakHebrew } from '../services/tts.js';
 
 const API_BASE_URL = 'http://localhost:3000/api';
 const USEFUL_LINKS_DRIVE_URL =
@@ -667,85 +667,6 @@ function Home({
     });
   };
 
-  const pronounceHebrewWord = (hebrewWord) => {
-    if (typeof window === 'undefined' || !window.speechSynthesis) {
-      return;
-    }
-
-    const spokenText = typeof hebrewWord === 'string' ? hebrewWord.trim() : '';
-    if (!spokenText) return;
-
-    const doSpeak = () => {
-      const utterance = new SpeechSynthesisUtterance(spokenText);
-      utterance.lang = 'he-IL';
-      utterance.rate = 0.85;
-      utterance.pitch = 1;
-      utterance.volume = 1;
-
-      const voices = window.speechSynthesis.getVoices();
-      const hebrewVoice =
-        voices.find((v) => v.lang === 'he-IL') ||
-        voices.find((v) => v.lang === 'he') ||
-        voices.find((v) => String(v.lang || '').startsWith('he-')) ||
-        null;
-
-      if (hebrewVoice) {
-        utterance.voice = hebrewVoice;
-      }
-
-      window.speechSynthesis.cancel();
-      window.setTimeout(() => {
-        window.speechSynthesis.speak(utterance);
-      }, 50);
-    };
-
-    const voices = window.speechSynthesis.getVoices();
-    if (voices && voices.length > 0) {
-      doSpeak();
-    } else {
-      // Speak once, whichever trigger comes first. Some browsers (notably
-      // Chromium on Linux) populate voices lazily and may never fire
-      // 'voiceschanged', so a timeout guarantees we still attempt to speak.
-      let started = false;
-      const start = () => {
-        if (started) return;
-        started = true;
-        doSpeak();
-      };
-      window.speechSynthesis.addEventListener('voiceschanged', start, { once: true });
-      window.setTimeout(start, 250);
-    }
-  };
-
-  const speakWord = async (hebrewWord) => {
-    const spokenText = typeof hebrewWord === 'string' ? hebrewWord.trim() : '';
-    if (!spokenText) return;
-
-    let audioBase64 = null;
-    try {
-      ({ audioBase64 } = await synthesizeSpeech({ text: spokenText }));
-    } catch (error) {
-      // Azure TTS endpoint threw (e.g. 401 dead key) — use the browser voice.
-      pronounceHebrewWord(spokenText);
-      return;
-    }
-
-    // Endpoint responded OK but Azure produced no audio (audioBase64: null).
-    if (!audioBase64) {
-      pronounceHebrewWord(spokenText);
-      return;
-    }
-
-    try {
-      const audio = new Audio(`data:audio/mpeg;base64,${audioBase64}`);
-      // play() returns a promise that can reject (decode/autoplay) without
-      // throwing synchronously — await so the catch reaches the fallback.
-      await audio.play();
-    } catch (error) {
-      pronounceHebrewWord(spokenText);
-    }
-  };
-
   const scrollGames = (direction) => {
     const scroller = gamesScrollerRef.current;
     if (!scroller) return;
@@ -953,7 +874,7 @@ function Home({
                       <span className="mt-1 block text-3xl font-black text-amber-600">
                         {loading ? '–' : chatsDisplay}
                       </span>
-                      <span className="mt-0.5 block text-xs font-bold text-slate-500">{heroDaysSuffix}</span>
+                      <span className="mt-0.5 block text-base font-bold text-slate-500">{heroDaysSuffix}</span>
                     </span>
                     <span className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 text-amber-600">
                       <Flame className="h-6 w-6" aria-hidden="true" />
@@ -1056,7 +977,7 @@ function Home({
               <h2 className="text-[clamp(1.55rem,2vw,2.5rem)] font-black text-slate-950">
                 {dictionaryTitle}
               </h2>
-              <p className="mt-2 text-[clamp(0.95rem,1vw,1.1rem)] font-medium leading-7 text-slate-600">
+              <p className="mt-2 text-[clamp(1.25rem,1vw,1.5rem)] font-medium leading-7 text-slate-600">
                 {dictionaryDescription}
               </p>
 
@@ -1139,7 +1060,7 @@ function Home({
                         <td className="px-3 py-3 text-center">
                           <button
                             type="button"
-                            onClick={() => speakWord(word.hebrew)}
+                            onClick={() => speakHebrew(word.hebrew)}
                             className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-violet-50 text-violet-600 transition hover:-translate-y-0.5 hover:bg-violet-600 hover:text-white"
                             aria-label={`השמע את ${word.hebrew}`}
                           >
@@ -1201,7 +1122,7 @@ function Home({
               <h2 className="mt-3 text-2xl font-black text-slate-950 lg:text-3xl">
                 {gamesText.title}
               </h2>
-              <p className="mt-1.5 max-w-2xl text-sm font-medium leading-6 text-slate-600">
+              <p className="mt-1.5 max-w-2xl text-lg font-medium leading-6 text-slate-600">
                 {gamesText.subtitle}
               </p>
             </div>
@@ -1250,11 +1171,11 @@ function Home({
                       <span className="block text-base font-black text-slate-900">
                         {category.meta[isArabic ? 'ar' : 'he']}
                       </span>
-                      <span className="mt-1 block text-xs font-bold text-slate-500">
+                      <span className="mt-1 block text-base font-bold text-slate-500">
                         {gamesText.completed(completedCount, category.numLevels)}
                       </span>
                     </span>
-                    <span className="flex flex-wrap items-center justify-center gap-1.5 text-xs font-bold text-slate-500">
+                    <span className="flex flex-wrap items-center justify-center gap-1.5 text-base font-bold text-slate-500">
                       <span>{gamesText.words(category.totalWords)}</span>
                       <span className="opacity-40">·</span>
                       <span>{gamesText.levels(category.numLevels)}</span>

--- a/frontend/src/pages/admin/Dashboard.jsx
+++ b/frontend/src/pages/admin/Dashboard.jsx
@@ -114,11 +114,11 @@ function OverviewCard({ stat }) {
         </span>
       </div>
 
-      <h2 className="mt-4 text-sm font-black text-slate-900">
+      <h2 className="mt-4 text-lg font-black text-slate-900">
         {stat.title}
       </h2>
 
-      <p className="mt-1 text-xs font-semibold leading-5 text-slate-600">
+      <p className="mt-1 text-base font-semibold leading-5 text-slate-600">
         {stat.detail}
       </p>
     </article>
@@ -162,18 +162,18 @@ function DashboardSection({
         </span>
 
         <div className="min-w-0 flex-1">
-          <h2 className="text-xl font-black leading-7 text-[#160A52]">
+          <h2 className="text-3xl font-black leading-7 text-[#160A52]">
             {section.title}
           </h2>
 
-          <p className="mt-2 max-w-[24rem] text-sm font-semibold leading-6 text-slate-600">
+          <p className="mt-2 max-w-[24rem] text-lg font-semibold leading-6 text-slate-600">
             {section.subtitle}
           </p>
         </div>
       </div>
 
       <div className="mt-6 flex items-center justify-between gap-3 rounded-[20px] bg-violet-50/45 px-4 py-3 transition duration-300 group-hover:bg-violet-50">
-        <p className="text-sm font-bold leading-6 text-slate-600">
+        <p className="text-lg font-bold leading-6 text-slate-600">
           {section.detail}
         </p>
 
@@ -192,14 +192,14 @@ function MiniDistribution({ data, metric }) {
     <div className="grid gap-2">
       {data.map((item) => (
         <div key={`${metric}-${item.level}`} className="grid grid-cols-[2.5rem_1fr_2.25rem] items-center gap-2">
-          <span className="text-xs font-black text-violet-800">{item.level}</span>
+          <span className="text-base font-black text-violet-800">{item.level}</span>
           <span className="h-2 overflow-hidden rounded-full bg-white/70 shadow-[inset_0_0_0_1px_rgba(221,214,254,0.7)]">
             <span
               className="block h-full rounded-full bg-gradient-to-l from-violet-600 to-fuchsia-400"
               style={{ width: `${Math.max(10, (item[metric] / maxValue) * 100)}%` }}
             />
           </span>
-          <span className="text-left text-xs font-black text-slate-600">{item[metric]}</span>
+          <span className="text-left text-base font-black text-slate-600">{item[metric]}</span>
         </div>
       ))}
     </div>
@@ -282,11 +282,11 @@ function AnalyticsOverview({ navigate }) {
     <section className="mt-3 rounded-[28px] border border-white/70 bg-[linear-gradient(135deg,rgba(255,255,255,0.84)_0%,rgba(245,240,255,0.82)_46%,rgba(255,241,248,0.78)_100%)] p-4 shadow-[0_22px_60px_rgba(109,40,217,0.12)] backdrop-blur-xl sm:mt-6 sm:p-5">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <p className="inline-flex items-center gap-2 rounded-full bg-violet-100/80 px-3 py-1 text-xs font-black text-violet-700">
+          <p className="inline-flex items-center gap-2 rounded-full bg-violet-100/80 px-3 py-1 text-base font-black text-violet-700">
             <Sparkles className="h-4 w-4" aria-hidden="true" />
             {t('admin.dashboard.overview.badge')}
           </p>
-          <h2 className="mt-2 text-xl font-black text-[#160A52] sm:text-2xl">
+          <h2 className="mt-2 text-3xl font-black text-[#160A52] sm:text-4xl">
             {t('admin.dashboard.overview.title')}
           </h2>
         </div>
@@ -294,7 +294,7 @@ function AnalyticsOverview({ navigate }) {
         <button
           type="button"
           onClick={() => navigate('/admin/analytics')}
-          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-sm font-black text-white shadow-button transition hover:-translate-y-0.5 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2"
+          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-violet-600 px-5 py-2 text-lg font-black text-white shadow-button transition hover:-translate-y-0.5 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2"
         >
           <BarChart3 className="h-4 w-4" aria-hidden="true" />
           {t('admin.dashboard.overview.viewFullAnalytics')}
@@ -304,7 +304,7 @@ function AnalyticsOverview({ navigate }) {
       <div className="mt-4 grid gap-3 lg:grid-cols-[1.2fr_1fr_1.1fr]">
         <article className="rounded-[22px] border border-violet-100/70 bg-white/72 p-4 shadow-[0_10px_28px_rgba(109,40,217,0.08)]">
           <div className="mb-3 flex items-center justify-between gap-3">
-            <h3 className="text-sm font-black text-slate-800">{t('admin.dashboard.overview.studentsDistribution')}</h3>
+            <h3 className="text-lg font-black text-slate-800">{t('admin.dashboard.overview.studentsDistribution')}</h3>
             <PieChart className="h-5 w-5 text-violet-600" aria-hidden="true" />
           </div>
           <MiniDistribution data={studentsByLevel} metric="students" />
@@ -337,9 +337,9 @@ function AnalyticsOverview({ navigate }) {
               return (
                 <div key={item.label} className="rounded-2xl bg-violet-50/80 px-2 py-3">
                   <Icon className="mx-auto h-4 w-4 text-violet-700" aria-hidden="true" />
-                  <p className="mt-2 text-base font-black text-[#160A52]">{item.value}</p>
-                  <p className="mt-1 text-[11px] font-black leading-4 text-slate-600">{item.label}</p>
-                  <p className="mt-1 text-[10px] font-bold text-violet-700">{item.detail}</p>
+                  <p className="mt-2 text-xl font-black text-[#160A52]">{item.value}</p>
+                  <p className="mt-1 text-[15px] font-black leading-4 text-slate-600">{item.label}</p>
+                  <p className="mt-1 text-[14px] font-bold text-violet-700">{item.detail}</p>
                 </div>
               );
             })}
@@ -348,18 +348,18 @@ function AnalyticsOverview({ navigate }) {
 
         <article className="rounded-[22px] border border-violet-100/70 bg-white/72 p-4 shadow-[0_10px_28px_rgba(109,40,217,0.08)]">
           <div className="mb-3 flex items-center justify-between gap-3">
-            <h3 className="text-sm font-black text-slate-800">{t('admin.dashboard.overview.wordsByLevel')}</h3>
+            <h3 className="text-lg font-black text-slate-800">{t('admin.dashboard.overview.wordsByLevel')}</h3>
             <BookOpenCheck className="h-5 w-5 text-violet-600" aria-hidden="true" />
           </div>
           <div className="flex h-24 items-end justify-between gap-2 rounded-2xl bg-violet-50/60 px-3 py-2">
             {wordsByLevel.map((item) => (
               <div key={item.level} className="flex h-full flex-1 flex-col items-center justify-end gap-1">
-                <span className="text-[11px] font-black text-violet-800">{item.words}</span>
+                <span className="text-[15px] font-black text-violet-800">{item.words}</span>
                 <span
                   className="w-full rounded-t-full bg-gradient-to-t from-violet-600 to-fuchsia-300"
                   style={{ height: `${Math.max(8, (item.words / maxWords) * 100)}%` }}
                 />
-                <span className="text-[11px] font-black text-violet-800">{item.level}</span>
+                <span className="text-[15px] font-black text-violet-800">{item.level}</span>
               </div>
             ))}
           </div>
@@ -369,7 +369,7 @@ function AnalyticsOverview({ navigate }) {
       <div className="mt-3 grid gap-2 sm:grid-cols-4">
         {overviewStats.map((stat) => (
           <div key={stat.name} className="rounded-2xl bg-white/65 px-3 py-2 shadow-[inset_0_0_0_1px_rgba(221,214,254,0.65)]">
-            <div className="flex items-center justify-between gap-2 text-xs font-black text-slate-600">
+            <div className="flex items-center justify-between gap-2 text-base font-black text-slate-600">
               <span className="inline-flex items-center gap-1.5">
                 {stat.name === t('admin.dashboard.stats.sharedChats') ? (
                   <Share2 className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
@@ -679,13 +679,13 @@ function AdminDashboard() {
 
             {/* Text — right side with gap from visual */}
             <div className="flex flex-1 flex-col justify-center text-right" style={{ paddingLeft: '4px', paddingRight: '20px' }} dir="rtl">
-              <p className="text-xs font-black text-violet-700 mb-1">
+              <p className="text-base font-black text-violet-700 mb-1">
                 {t('admin.dashboard.hero.greeting')}{user?.name || t('admin.dashboard.hero.defaultAdminName')}
               </p>
               <h1 className="text-3xl font-black leading-tight text-slate-950 md:text-4xl">
                 {t('admin.dashboard.hero.title')}
               </h1>
-              <p className="mt-1 text-sm font-semibold text-slate-600">
+              <p className="mt-1 text-lg font-semibold text-slate-600">
                 {t('admin.dashboard.hero.subtitle')}
               </p>
             </div>

--- a/frontend/src/services/tts.js
+++ b/frontend/src/services/tts.js
@@ -1,0 +1,65 @@
+import { synthesizeSpeech } from './chat.js';
+
+// Browser Web Speech fallback. Speaks Hebrew via speechSynthesis.
+// Handles Chromium-on-Linux, which populates voices lazily and may never
+// fire 'voiceschanged' — a 250ms timeout guarantees we still attempt to speak.
+function speakViaBrowser(text) {
+  const spokenText = typeof text === 'string' ? text.trim() : '';
+  if (!spokenText || typeof window === 'undefined' || !window.speechSynthesis) {
+    return;
+  }
+  const doSpeak = () => {
+    const utterance = new SpeechSynthesisUtterance(spokenText);
+    utterance.lang = 'he-IL';
+    utterance.rate = 0.85;
+    utterance.pitch = 1;
+    utterance.volume = 1;
+    const voices = window.speechSynthesis.getVoices?.() || [];
+    const hebrewVoice =
+      voices.find((v) => v.lang === 'he-IL') ||
+      voices.find((v) => v.lang === 'he') ||
+      voices.find((v) => String(v.lang || '').startsWith('he-')) ||
+      null;
+    if (hebrewVoice) utterance.voice = hebrewVoice;
+    window.speechSynthesis.cancel();
+    window.setTimeout(() => window.speechSynthesis.speak(utterance), 50);
+  };
+  const voices = window.speechSynthesis.getVoices?.() || [];
+  if (voices.length > 0) {
+    doSpeak();
+  } else {
+    let started = false;
+    const start = () => {
+      if (started) return;
+      started = true;
+      doSpeak();
+    };
+    window.speechSynthesis.addEventListener('voiceschanged', start, { once: true });
+    window.setTimeout(start, 250);
+  }
+}
+
+// Primary: Azure TTS (rich he-IL neural voice). Falls back to the browser
+// voice on any failure: thrown error, null audio, or a rejected play promise.
+export async function speakHebrew(text) {
+  const spokenText = typeof text === 'string' ? text.trim() : '';
+  if (!spokenText) return;
+  let audioBase64 = null;
+  try {
+    const result = await synthesizeSpeech({ text: spokenText });
+    audioBase64 = result?.audioBase64 ?? null;
+  } catch {
+    speakViaBrowser(spokenText);
+    return;
+  }
+  if (!audioBase64) {
+    speakViaBrowser(spokenText);
+    return;
+  }
+  try {
+    const audio = new Audio(`data:audio/mpeg;base64,${audioBase64}`);
+    await audio.play();
+  } catch {
+    speakViaBrowser(spokenText);
+  }
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1461,7 +1461,7 @@ a {
   background: white;
   color: var(--color-muted);
   font: inherit;
-  font-size: 0.72rem;
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
   user-select: none;
@@ -1702,7 +1702,7 @@ a {
 
 .chat-empty-state__title {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.5rem;
   font-weight: 800;
   color: var(--color-text);
 }
@@ -1710,7 +1710,7 @@ a {
 .chat-empty-state__description {
   margin: 0;
   max-width: 26rem;
-  font-size: 0.95rem;
+  font-size: 1.125rem;
   color: var(--color-muted);
   line-height: 1.6;
 }
@@ -1804,13 +1804,13 @@ a {
 }
 
 .chatbot-toolbar__title {
-  font-size: 0.9rem;
+  font-size: 1rem;
   font-weight: 800;
   color: var(--color-text);
 }
 
 .chatbot-toolbar__hint {
-  font-size: 0.7rem;
+  font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-muted);
   white-space: nowrap;
@@ -1835,7 +1835,7 @@ a {
   background: #fff;
   color: var(--color-primary);
   font: inherit;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   font-weight: 700;
   transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
 }
@@ -2001,7 +2001,7 @@ a {
   background: transparent;
   color: #6d28d9;
   font: inherit;
-  font-size: 0.8rem;
+  font-size: 1rem;
   font-weight: 700;
   cursor: pointer;
   transition: color 160ms ease, background 160ms ease, box-shadow 160ms ease;


### PR DESCRIPTION
Adds Azure TTS (with browser fallback) to the dictionary and all vocab-game pronounce buttons, via a shared speakHebrew helper.
Fixes text_to_speech.py crash: CancellationDetails.from_result() → CancellationDetails(result) for Speech SDK 1.49 (this was breaking chat voice too).
Increases font sizes across home, games, vocab game, chatbot, and admin dashboard for readability.

Reviewer note: TTS needs a valid AZURE_SPEECH_KEY + AZURE_SPEECH_REGION=swedencentral to hear the Azure voice — confirmed working with a valid key on my end.